### PR TITLE
Audio via ffmpeg pulse device instead of alsa

### DIFF
--- a/stream.py
+++ b/stream.py
@@ -110,7 +110,7 @@ def get_join_url():
     return bbb.get_join_meeting_url(args.user,args.id, pwd)
 
 def stream_intro():
-    audio_options = '-f alsa -i pulse -ac 2 -c:a aac -b:a 160k -ar 44100'
+    audio_options = '-f pulse -i default -ac 2 -c:a aac -b:a 160k -ar 44100'
     video_options = '-c:v libx264 -x264-params "nal-hrd=cbr" -profile:v high -level:v 4.2 -vf format=yuv420p -b:v 4000k -maxrate 4000k -minrate 2000k -bufsize 8000k -g 60 -preset ultrafast'
     introBegin = ""
     if args.beginIntroAt:
@@ -124,7 +124,7 @@ def stream_intro():
     p = subprocess.call(ffmpeg_args)
 
 def stream():
-    audio_options = '-f alsa -i pulse -ac 2 -c:a aac -b:a 160k -ar 44100'
+    audio_options = '-f pulse -i default -ac 2 -c:a aac -b:a 160k -ar 44100'
     #video_options = ' -c:v libvpx-vp9 -b:v 2000k -crf 33 -quality realtime -speed 5'
     video_options = '-c:v libx264 -x264-params "nal-hrd=cbr" -profile:v high -level:v 4.2 -vf format=yuv420p -b:v 4000k -maxrate 4000k -minrate 2000k -bufsize 8000k -g 60 -preset ultrafast -tune zerolatency'
     ffmpeg_stream = 'ffmpeg -thread_queue_size 1024 -f x11grab -draw_mouse 0 -s 1920x1080  -i :%d -thread_queue_size 1024 %s -threads 0 %s -f flv -flvflags no_duration_filesize "%s"' % ( 122, audio_options, video_options, args.target)
@@ -134,7 +134,7 @@ def stream():
 
 def download():
     downloadFile = "/video/meeting-%s.mkv" % fileTimeStamp 
-    audio_options = '-f alsa -i pulse -ac 2'
+    audio_options = '-f pulse -i default -ac 2'
     video_options = '-c:v libx264rgb -crf 0 -preset ultrafast'
     ffmpeg_stream = 'ffmpeg -thread_queue_size 1024 -f x11grab -draw_mouse 0 -s 1920x1080  -i :%d -thread_queue_size 1024 %s %s %s' % ( 122, audio_options, video_options, downloadFile)
     ffmpeg_args = shlex.split(ffmpeg_stream)


### PR DESCRIPTION
The ffmpeg pulse input device might be a more efficient way to capture the audio rather than taking a round-trip through alsa.

As per #62, we are running into some performance issues on low-end virtual machines and trying to optimize the pipeline some.