### PR TITLE
make pulseaudio startup more robust

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,30 @@
-#!/bin/sh
+#!/bin/bash
 
-pulseaudio --start -vvv --disallow-exit --log-target=syslog --high-priority --exit-idle-time=-1 --daemonize
+if pulseaudio --check ; then
+	echo "Pulseaudio already running - killing it..."
+	pulseaudio --kill
+fi
 
-exec "$@"
+# sometimes pulseaudio fails to start (for unknown reason - try starting it again)
+p=0
+
+while ! pulseaudio --check && [ $p -lt 2 ] ; do
+	echo "Starting pulseaudio..."
+	pulseaudio --start -vvv --disallow-exit --log-target=syslog --high-priority --exit-idle-time=-1 &
+
+	i=0
+
+	while ! pulseaudio --check && [ $i -lt 3 ] ; do
+		echo "Waiting for pulseaudio to start..."
+		sleep 1
+		i=$((i+1))
+	done
+
+	p=$((p+1))
+done
+
+if pulseaudio --check ; then
+	exec "$@"
+else
+	echo "Error starting pulseaudio"
+fi

--- a/stream.py
+++ b/stream.py
@@ -80,8 +80,11 @@ def bbb_browser():
 
     element = EC.invisibility_of_element((By.CSS_SELECTOR, '.ReactModal__Overlay'))
     WebDriverWait(browser, selelnium_timeout).until(element)
-    browser.find_element_by_id('message-input').send_keys("This meeting is streamed to: %s" % args.target.partition('//')[2].partition('/')[0])
-    browser.find_elements_by_css_selector('[aria-label="Send message"]')[0].click()
+    element = browser.find_element_by_id('message-input')
+    chat_send = browser.find_elements_by_css_selector('[aria-label="Send message"]')[0]
+    if element.is_enabled() and chat_send.is_enabled():
+       element.send_keys("This meeting is streamed to: %s" % args.target.partition('//')[2].partition('/')[0])
+       chat_send.click()
     
     if args.chat:
         browser.execute_script("document.querySelector('[aria-label=\"User list\"]').parentElement.style.display='none';")
@@ -112,7 +115,7 @@ def get_join_url():
     joinParams['fullName'] = args.user
     joinParams['password'] = pwd
     joinParams['userdata-bbb_auto_join_audio'] = "true" 
-    joinParams['userdata-bbb_enable_video'] = 'false' 
+    joinParams['userdata-bbb_enable_video'] = 'true' 
     joinParams['userdata-bbb_listen_only_mode'] = "true" 
     joinParams['userdata-bbb_force_listen_only'] = "true" 
     joinParams['userdata-bbb_skip_check_audio'] = 'true' 


### PR DESCRIPTION
Sometimes pulseaudio seems to fail to startup (then we'll get an input/output error). I couldn't figure out why, so I added a check. If it didn't come up within 3 seconds, we'll try to start it again - usually works then.