### PR TITLE
Fix default locale setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.yml
 *.code-workspace
 *.iml
+*.swp

--- a/chat.py
+++ b/chat.py
@@ -11,7 +11,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 
 browser = None
-selelnium_timeout = 30
+selenium_timeout = 30
 connect_timeout = 5
 
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
@@ -67,11 +67,11 @@ def bbb_browser():
     browser.get(join_url)
 
     element = EC.presence_of_element_located((By.XPATH, '//span[contains(@class,"success")]'))
-    WebDriverWait(browser, selelnium_timeout).until(element)
+    WebDriverWait(browser, selenium_timeout).until(element)
     browser.find_elements_by_xpath('//span[contains(@class,"success")]')[0].click()
 
     element = EC.invisibility_of_element((By.CSS_SELECTOR, '.ReactModal__Overlay'))
-    WebDriverWait(browser, selelnium_timeout).until(element)
+    WebDriverWait(browser, selenium_timeout).until(element)
     browser.find_element_by_id('message-input').send_keys("Viewers of the live stream can now send messages to this meeting")
     browser.find_elements_by_css_selector('[aria-label="Send message"]')[0].click()
 

--- a/stream.py
+++ b/stream.py
@@ -17,7 +17,7 @@ from datetime import datetime
 
 downloadProcess = None
 browser = None
-selelnium_timeout = 30
+selenium_timeout = 30
 connect_timeout = 5
 
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
@@ -52,7 +52,7 @@ def set_up():
     options.add_argument('--kiosk') 
     options.add_argument('--window-size=1920,1080')
     options.add_argument('--window-position=0,0')
-    options.add_experimental_option("excludeSwitches", ['enable-automation']);   
+    options.add_experimental_option("excludeSwitches", ['enable-automation'])
     options.add_experimental_option('prefs', {'intl.accept_languages':'{locale}'.format(locale='en_US.UTF-8')})
     options.add_argument('--shm-size=1gb') 
     options.add_argument('--disable-dev-shm-usage') 
@@ -77,11 +77,11 @@ def bbb_browser():
     browser.get(join_url)
 
     element = EC.presence_of_element_located((By.XPATH, '//span[contains(@class,"success")]'))
-    WebDriverWait(browser, selelnium_timeout).until(element)
+    WebDriverWait(browser, selenium_timeout).until(element)
     browser.find_elements_by_xpath('//span[contains(@class,"success")]')[0].click()
 
     element = EC.invisibility_of_element((By.CSS_SELECTOR, '.ReactModal__Overlay'))
-    WebDriverWait(browser, selelnium_timeout).until(element)
+    WebDriverWait(browser, selenium_timeout).until(element)
 
     try:
         element = browser.find_element_by_id('message-input')

--- a/stream.py
+++ b/stream.py
@@ -53,6 +53,7 @@ def set_up():
     options.add_argument('--window-size=1920,1080')
     options.add_argument('--window-position=0,0')
     options.add_experimental_option("excludeSwitches", ['enable-automation']);   
+    options.add_experimental_option('prefs', {'intl.accept_languages':'{locale}'.format(locale='en_US.UTF-8')})
     options.add_argument('--shm-size=1gb') 
     options.add_argument('--disable-dev-shm-usage') 
     options.add_argument('--start-fullscreen') 


### PR DESCRIPTION
This pull request adds a 'locale' setting for Chrome webDriver, which is 'en_US.UTF-8'.

This parameter is needed as some of the following code is relying on 'hard coded' english parameters ( ex : css selector "Send message" ).
I've also added just a lint about a variable which had a typo in it ( according to me so I may be wrong ).

This PR fixes #89 , opened by me and misunderstood at the beginning.