### PR TITLE
Message toogle

### DIFF
--- a/stream.py
+++ b/stream.py
@@ -167,7 +167,7 @@ def bbb_browser():
     time.sleep(10)
     if not args.chat:
         try:
-            element = browser.find_elements_by_css_selector('button[aria-label="Users and messages toggle"]')[0]
+            element = browser.find_elements_by_css_selector('button[aria-label^="Users and messages toggle"]')[0]
             if element.is_enabled():
                 element.click()
         except NoSuchElementException:

--- a/stream.py
+++ b/stream.py
@@ -7,6 +7,7 @@ from bigbluebutton_api_python import BigBlueButton, exception
 from bigbluebutton_api_python import util as bbbUtil 
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys  
+from selenium.common.exceptions import JavascriptException
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.chrome.options import Options  
 from selenium.webdriver.support.ui import WebDriverWait
@@ -175,7 +176,7 @@ def bbb_browser():
  
     try:
         browser.execute_script("document.querySelector('[aria-label=\"Users and messages toggle\"]').style.display='none';")
-    except selenium.common.exceptions.JavascriptException:
+    except JavascriptException:
         browser.execute_script("document.querySelector('[aria-label=\"Users and messages toggle with new message notification\"]').style.display='none';")
     browser.execute_script("document.querySelector('[aria-label=\"Options\"]').style.display='none';")
     browser.execute_script("document.querySelector('[aria-label=\"Actions bar\"]').style.display='none';")

--- a/stream.py
+++ b/stream.py
@@ -173,7 +173,10 @@ def bbb_browser():
         except NoSuchElementException:
             logging.info("could not find users and messages toggle")
  
-    browser.execute_script("document.querySelector('[aria-label=\"Users and messages toggle\"]').style.display='none';")
+    try:
+        browser.execute_script("document.querySelector('[aria-label=\"Users and messages toggle\"]').style.display='none';")
+    except selenium.common.exceptions.JavascriptException:
+        browser.execute_script("document.querySelector('[aria-label=\"Users and messages toggle with new message notification\"]').style.display='none';")
     browser.execute_script("document.querySelector('[aria-label=\"Options\"]').style.display='none';")
     browser.execute_script("document.querySelector('[aria-label=\"Actions bar\"]').style.display='none';")
     browser.execute_script("document.getElementById('container').setAttribute('style','margin-bottom:30px');")


### PR DESCRIPTION
Matches for element selection with 'starts with' instead of equals, and catches the exception if the base element for match users is not present. Fixes #122 

This time the checked in version has been double-tested. -.-'