### PR TITLE
fix(exception)

### DIFF
--- a/stream.py
+++ b/stream.py
@@ -7,6 +7,7 @@ from bigbluebutton_api_python import BigBlueButton, exception
 from bigbluebutton_api_python import util as bbbUtil 
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys  
+from selenium.common.exceptions import ElementClickInterceptedException
 from selenium.common.exceptions import JavascriptException
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.chrome.options import Options  
@@ -162,7 +163,10 @@ def bbb_browser():
             if element.is_enabled():
                 element.click()
     except NoSuchElementException:
-        # ignore (chat might be disabled) 
+        # ignore (chat might be disabled)
+        logging.info("could not find chat input or chat toggle")
+    except ElementClickInterceptedException:
+        # ignore (chat might be disabled)
         logging.info("could not find chat input or chat toggle")
 
     time.sleep(10)


### PR DESCRIPTION
```
# docker logs cd347bc667c6
Setting up nsswrapper mapping 1001 to lithium
Starting pulseaudio...
Waiting for pulseaudio to start...
Skipping nsswrapper setup - already initialized
INFO:root:Starting browser!!
INFO:root:Open BBB and hide elements!!
INFO:root:get_join_url...
INFO:root:https://scalelite.example.com/bigbluebutton/api/join?meetingID=xxx&fullName=Live&password=xxx&userdata-bbb_auto_join_audio=true&userdata-bbb_enable_video=true&userdata-bbb_listen_only_mode=true&userdata-bbb_force_listen_only=true&userdata-bbb_skip_check_audio=true&joinViaHtml5=true&checksum=xxx
INFO:root:Waiting for chat input window to appear.
Traceback (most recent call last):
  File "stream.py", line 258, in <module>
    bbb_browser()
  File "stream.py", line 159, in bbb_browser
    chat_send.click()
  File "/usr/local/lib/python3.6/dist-packages/selenium/webdriver/remote/webelement.py", line 80, in click
    self._execute(Command.CLICK_ELEMENT)
  File "/usr/local/lib/python3.6/dist-packages/selenium/webdriver/remote/webelement.py", line 633, in _execute
    return self._parent.execute(command, params)
  File "/usr/local/lib/python3.6/dist-packages/selenium/webdriver/remote/webdriver.py", line 321, in execute
    self.error_handler.check_response(response)
  File "/usr/local/lib/python3.6/dist-packages/selenium/webdriver/remote/errorhandler.py", line 242, in check_response
    raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.ElementClickInterceptedException: Message: element click intercepted: Element <button aria-label="Send message" aria-disabled="false" class="md--Q7ug4 buttonWrapper--x8uow sendButton--Z93EzE" type="submit" position="bottom" id="tippy-47">...</button> is not clickable at point (500, 1025). Other element would receive the click: <div class="ReactModal__Overlay ReactModal__Overlay--after-open overlay--Z7FUVK">...</div>
  (Session info: chrome=90.0.4430.93)
```

As reported in https://github.com/aau-zid/BigBlueButton-liveStreaming/issues/124

Somehow, the chat button refuses to work.
If so, it may be better to just ignore this and start streaming, rather the crash.

