### PR TITLE
feat(chat-message): allow for custom message definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You need to set some environment variables to run the container.
 * BBB_USER_NAME - the username to join the meeting. (Default: Live)
 * BBB_SHOW_CHAT - shows the chat on the left side of the window (Default: false)
 * BBB_RESOLUTION - the streamed/downloaded resolution (Default: 1920x1080)
+* BBB_CHAT_MESSAGE - prefix for the message that would be posted to BBB chat, while joining a conference (Default: "This meeting is streamed to")
 * TZ - Timezone (Default: Europe/Vienna)
 
 #### Chat settings

--- a/chat.py
+++ b/chat.py
@@ -85,8 +85,15 @@ def bbb_browser():
 
     element = EC.invisibility_of_element((By.CSS_SELECTOR, '.ReactModal__Overlay'))
     WebDriverWait(browser, selenium_timeout).until(element)
-    browser.find_element_by_id('message-input').send_keys("Viewers of the live stream can now send messages to this meeting")
-    browser.find_elements_by_css_selector('[aria-label="Send message"]')[0].click()
+
+    element = browser.find_element_by_id('message-input')
+    chat_send = browser.find_elements_by_css_selector('[aria-label="Send message"]')[0]
+    # ensure chat is enabled (might be locked by moderator)
+    if element.is_enabled() and chat_send.is_enabled():
+       tmp_chatMsg = os.environ.get('BBB_CHAT_MESSAGE', "Viewers of the live stream can now send messages to this meeting")
+       if not tmp_chatMsg in [ 'false', 'False', 'FALSE' ]:
+           element.send_keys(tmp_chatMsg)
+           chat_send.click()
 
     redis_r = redis.Redis(host=args.redis,charset="utf-8", decode_responses=True)
     redis_s = redis_r.pubsub()

--- a/examples/.env.chat_example
+++ b/examples/.env.chat_example
@@ -16,3 +16,5 @@ BBB_REDIS_HOST=redis
 BBB_REDIS_CHANNEL=chat
 # Username for the chat (default: 'Chat')
 BBB_CHAT_NAME=Chat
+# Message to post in BBB Chat when joining a conference
+BBB_CHAT_MESSAGE=This meeting is streamed to

--- a/examples/.env.chat_example
+++ b/examples/.env.chat_example
@@ -17,4 +17,4 @@ BBB_REDIS_CHANNEL=chat
 # Username for the chat (default: 'Chat')
 BBB_CHAT_NAME=Chat
 # Message to post in BBB Chat when joining a conference
-BBB_CHAT_MESSAGE=This meeting is streamed to
+BBB_CHAT_MESSAGE=Viewers of the live stream can now send messages to this meeting

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -14,3 +14,5 @@ BBB_MODERATOR_PASSWORD=JjeQYksarqLQ
 BBB_MEETING_TITLE=liveStreaming Test
 # Media server url:
 BBB_STREAM_URL=rtmp://media_server_url/stream/stream_key
+# Message to post in BBB Chat when joining a conference
+BBB_CHAT_MESSAGE=This meeting is streamed to

--- a/examples/docker-compose.yml.chat_example
+++ b/examples/docker-compose.yml.chat_example
@@ -20,6 +20,8 @@ services:
       - BBB_ENABLE_CHAT=true
       # show chat in live stream
       - BBB_SHOW_CHAT=false
+      # Message to post in BBB Chat when joining a conference
+      - BBB_CHAT_MESSAGE=This meeting is streamed to
       # Set REDIS host (default: 'redis')
       - BBB_REDIS_HOST=redis
       # Set REDIS channel to subscribe (default: 'chat')

--- a/examples/docker-compose.yml.chat_example
+++ b/examples/docker-compose.yml.chat_example
@@ -21,7 +21,7 @@ services:
       # show chat in live stream
       - BBB_SHOW_CHAT=false
       # Message to post in BBB Chat when joining a conference
-      - BBB_CHAT_MESSAGE=This meeting is streamed to
+      - BBB_CHAT_MESSAGE=Viewers of the live stream can now send messages to this meeting
       # Set REDIS host (default: 'redis')
       - BBB_REDIS_HOST=redis
       # Set REDIS channel to subscribe (default: 'chat')

--- a/examples/docker-compose.yml.example
+++ b/examples/docker-compose.yml.example
@@ -29,6 +29,8 @@ services:
       - BBB_END_INTRO_AT=
       # Media server url:
       - BBB_STREAM_URL=rtmp://media_server_url/stream/stream_key
+      # Message to post in BBB Chat when joining a conference
+      - BBB_CHAT_MESSAGE=This meeting is streamed to
       # Resolution to be streamed/downloaded in format WxH (default 1920x1080)
       - BBB_RESOLUTION=1920x1080
       # stream video bitrate

--- a/stream.py
+++ b/stream.py
@@ -146,14 +146,15 @@ def bbb_browser():
         chat_send = browser.find_elements_by_css_selector('[aria-label="Send message"]')[0]
         # ensure chat is enabled (might be locked by moderator)
         if element.is_enabled() and chat_send.is_enabled():
-           tmp_chatUrl = args.target.partition('//')[2].partition('/')[0]
-           if args.chatUrl:
-               tmp_chatUrl = args.chatUrl
            tmp_chatMsg = os.environ.get('BBB_CHAT_MESSAGE', "This meeting is streamed to")
-           if args.chatMsg:
-               tmp_chatMsg = ' '.join(args.chatMsg).strip('"')
-           element.send_keys("{0}: {1}".format(tmp_chatMsg, tmp_chatUrl))
-           chat_send.click()
+           if not tmp_chatMsg in [ 'false', 'False', 'FALSE' ]:
+               tmp_chatUrl = args.target.partition('//')[2].partition('/')[0]
+               if args.chatUrl:
+                   tmp_chatUrl = args.chatUrl
+               if args.chatMsg:
+                   tmp_chatMsg = ' '.join(args.chatMsg).strip('"')
+               element.send_keys("{0}: {1}".format(tmp_chatMsg, tmp_chatUrl))
+               chat_send.click()
 
         if args.chat:
            browser.execute_script("document.querySelector('[aria-label=\"User list\"]').parentElement.style.display='none';")

--- a/stream.py
+++ b/stream.py
@@ -149,7 +149,7 @@ def bbb_browser():
            tmp_chatUrl = args.target.partition('//')[2].partition('/')[0]
            if args.chatUrl:
                tmp_chatUrl = args.chatUrl
-           tmp_chatMsg = "This meeting is streamed to"
+           tmp_chatMsg = os.environ.get('BBB_CHAT_MESSAGE', "This meeting is streamed to")
            if args.chatMsg:
                tmp_chatMsg = ' '.join(args.chatMsg).strip('"')
            element.send_keys("{0}: {1}".format(tmp_chatMsg, tmp_chatUrl))


### PR DESCRIPTION
Fixes https://github.com/aau-zid/BigBlueButton-liveStreaming/issues/115

Allows overriding the default message prefix, letting other attendees know bbb-livestreaming joined their conference.