### PR TITLE
fix(exception): catch

### DIFF
--- a/stream.py
+++ b/stream.py
@@ -178,6 +178,8 @@ def bbb_browser():
                 element.click()
         except NoSuchElementException:
             logging.info("could not find users and messages toggle")
+        except ElementClickInterceptedException:
+            logging.info("could not find users and messages toggle")
  
     try:
         browser.execute_script("document.querySelector('[aria-label=\"Users and messages toggle\"]').style.display='none';")


### PR DESCRIPTION
completing patch from https://github.com/aau-zid/BigBlueButton-liveStreaming/pull/125/files
handling another ElementClickInterceptedException as NoSuchElementException

should fix the error reported in https://github.com/aau-zid/BigBlueButton-liveStreaming/issues/124#issuecomment-860220579

Though I'm wondering why would those click get intercepted in the first place?
May be missing something ...