### PR TITLE
stream.py: fix syntax error

### DIFF
--- a/stream.py
+++ b/stream.py
@@ -156,7 +156,7 @@ def bbb_browser():
                    if args.chatMsg:
                        tmp_chatMsg = ' '.join(args.chatMsg).strip('"')
                    tmp_chatMsg = "{0}: {1}".format(tmp_chatMsg, tmp_chatUrl)
-               else if tmp_chatCustomMsg != '':
+               elif tmp_chatCustomMsg != '':
                    tmp_chatMsg = tmp_chatCustomMsg
                else:
                    tmp_chatMsg = "Recording in progress!"


### PR DESCRIPTION
Seems to be introduced by 3d333687b6a20a8d3f09ef6acd786e96b305123f and just merged in 60ca05084001c00a66349febf0e113e82cc6bd09.

```
bbb_streamer_1                    |   File "stream.py", line 159
bbb_streamer_1                    |     else if tmp_chatCustomMsg != '':
bbb_streamer_1                    |           ^
bbb_streamer_1                    | SyntaxError: invalid syntax
bbb-broadcaster_bbb_streamer_1 exited with code 1
```