### PR TITLE
UI tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You need to set some environment variables to run the container.
 * BBB_CHAT_MESSAGE - prefix for the message that would be posted to BBB chat, while joining a conference (Default: "This meeting is streamed to")
 * BBB_HIDE_MEETING_TITLE - hide the meeting title in the top bar (Default: false)
 * BBB_HIDE_WHO_TALKS - hide the annotation who is currently talking (Default: false)
+* BBB_BACKGROUND_COLOR - override background color by a CSS color, e.g., "black" or "#ffffff"
 * TZ - Timezone (Default: Europe/Vienna)
 
 #### Chat settings

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ You need to set some environment variables to run the container.
 * BBB_SHOW_CHAT - shows the chat on the left side of the window (Default: false)
 * BBB_RESOLUTION - the streamed/downloaded resolution (Default: 1920x1080)
 * BBB_CHAT_MESSAGE - prefix for the message that would be posted to BBB chat, while joining a conference (Default: "This meeting is streamed to")
+* BBB_HIDE_MEETING_TITLE - hide the meeting title in the top bar (Default: false)
+* BBB_HIDE_WHO_TALKS - hide the annotation who is currently talking (Default: false)
 * TZ - Timezone (Default: Europe/Vienna)
 
 #### Chat settings

--- a/stream.py
+++ b/stream.py
@@ -16,6 +16,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 
 from datetime import datetime
+from distutils.util import strtobool
 import time
 
 browser = None
@@ -71,6 +72,18 @@ parser.add_argument(
 parser.add_argument(
    '--browser-disable-dev-shm-usage', action='store_true', default=False,
    help='do not use /dev/shm',
+)
+parser.add_argument(
+    '--bbb-hide-meeting-title',
+    type=bool,
+    help='hide the meetings title in the top bar (can be set using env)',
+    default=bool(strtobool(os.environ.get('BBB_HIDE_MEETING_TITLE', '0')))
+)
+parser.add_argument(
+    '--bbb-hide-who-talks',
+    type=bool,
+    help='hide the annotation who is currently talking (can be set using env)',
+    default=bool(strtobool(os.environ.get('BBB_HIDE_WHO_TALKS', '0')))
 )
 
 args = parser.parse_args()
@@ -195,6 +208,11 @@ def bbb_browser():
     browser.execute_script("document.querySelector('div[class^=\"navbar\"] > div[class^=\"top\"] > div[class^=\"left\"]').style.display='none';")
     browser.execute_script("document.querySelectorAll('div[class^=\"navbar\"] > div[class^=\"top\"] > div[class^=\"center\"] > :not(h1)').forEach((ele) => ele.style.display='none');")
     browser.execute_script("document.querySelector('div[class^=\"navbar\"] > div[class^=\"top\"] > div[class^=\"right\"]').style.display='none';")
+
+    if args.bbb_hide_meeting_title:
+        browser.execute_script("document.querySelector('div[class^=\"navbar\"] > div[class^=\"top\"]').style.display='none';")
+    if args.bbb_hide_who_talks:
+        browser.execute_script("document.querySelector('div[class^=\"navbar\"] > div[class^=\"bottom\"]').style.display='none';")
 
     browser.execute_script("document.querySelector('[aria-label=\"Actions bar\"]').style.display='none';")
 

--- a/stream.py
+++ b/stream.py
@@ -191,12 +191,32 @@ def bbb_browser():
         except ElementClickInterceptedException:
             logging.info("could not find users and messages toggle")
  
-    try:
-        browser.execute_script("document.querySelector('[aria-label=\"Users and messages toggle\"]').style.display='none';")
-    except JavascriptException:
-        browser.execute_script("document.querySelector('[aria-label=\"Users and messages toggle with new message notification\"]').style.display='none';")
-    browser.execute_script("document.querySelector('[aria-label=\"Options\"]').style.display='none';")
+    # Remove everything from the top bar, except the meeting's title.
+    browser.execute_script("document.querySelector('div[class^=\"navbar\"] > div[class^=\"top\"] > div[class^=\"left\"]').style.display='none';")
+    browser.execute_script("document.querySelectorAll('div[class^=\"navbar\"] > div[class^=\"top\"] > div[class^=\"center\"] > :not(h1)').forEach((ele) => ele.style.display='none');")
+    browser.execute_script("document.querySelector('div[class^=\"navbar\"] > div[class^=\"top\"] > div[class^=\"right\"]').style.display='none';")
+
     browser.execute_script("document.querySelector('[aria-label=\"Actions bar\"]').style.display='none';")
+
+    browser.execute_script("""
+        const hideDecoratorsStyle = document.createElement("style");
+        hideDecoratorsStyle.innerText = `
+            /* Presentation hide minus button */
+            button[aria-label="Hide presentation"],
+            /* Fullscreen button, both for presentations and webcams */
+            button[aria-label^="Make "][aria-label$=" fullscreen"],
+            /* Drop down menu next to user names for webcam videos */
+            div[class^="videoCanvas"] span[class^="dropdownTrigger"]::after,
+            /* Interactive poll window */
+            div[class^="pollingContainer"],
+            /* Notification toasts */
+            div[class="Toastify"] {
+                display: none;
+            }
+        `;
+        document.head.appendChild(hideDecoratorsStyle);
+    """)
+
     try:
         browser.execute_script("document.getElementById('container').setAttribute('style','margin-bottom:30px');")
     except JavascriptException:

--- a/stream.py
+++ b/stream.py
@@ -85,6 +85,11 @@ parser.add_argument(
     help='hide the annotation who is currently talking (can be set using env)',
     default=bool(strtobool(os.environ.get('BBB_HIDE_WHO_TALKS', '0')))
 )
+parser.add_argument(
+    '--bbb-background-color',
+    help='override background color by a CSS color, e.g., "black" or "#ffffff" (can be set using env)',
+    default=os.environ.get('BBB_BACKGROUND_COLOR', '')
+)
 
 args = parser.parse_args()
 # some ugly hacks for additional options
@@ -239,6 +244,9 @@ def bbb_browser():
         browser.execute_script("document.getElementById('container').setAttribute('style','margin-bottom:30px');")
     except JavascriptException:
         browser.execute_script("document.getElementById('app').setAttribute('style','margin-bottom:30px');")
+
+    if args.bbb_background_color:
+        browser.execute_script("document.querySelector('body').setAttribute('style','background-color: %s;');" % args.bbb_background_color)
 
 def create_meeting():
     create_params = {}


### PR DESCRIPTION
This pull request introduces some changes to the BigBlueButton web UI to be displayed within the stream. As those cover different scopes, each is in its own commit.

In a nutshell, the
* first commit hides some interactive UI elements one simply cannot click in a video.
* second commit introduces two flags `BBB_HIDE_MEETING_TITLE` and `BBB_HIDE_WHO_TALKS` which allow hiding the relevant bar at the top.
* third commit allows overriding the background color from BBB's blue to whatever color one prefers.

More information is available in the commit messages.