### PR TITLE
stream.py: attempt to fix presence of chat message

### DIFF
--- a/stream.py
+++ b/stream.py
@@ -154,6 +154,7 @@ def bbb_browser():
     browser.get(join_url)
 
 
+    time.sleep(10)
     try:
         # Wait for the input element to appear
         logging.info("Waiting for chat input window to appear.")
@@ -181,6 +182,8 @@ def bbb_browser():
                
                element.send_keys(tmp_chatMsg)
                chat_send.click()
+        else:
+            logging.info("chat is not enabled")
 
         if args.chat:
             try:
@@ -193,12 +196,12 @@ def bbb_browser():
                 element.click()
     except NoSuchElementException:
         # ignore (chat might be disabled)
-        logging.info("could not find chat input or chat toggle")
-    except ElementClickInterceptedException:
+        logging.warn("could not find chat input or chat toggle")
+    except ElementClickInterceptedException as e:
         # ignore (chat might be disabled)
-        logging.info("could not find chat input or chat toggle")
+        logging.warn("could not find chat input or chat toggle")
+        logging.warn(e, exc_info=True)
 
-    time.sleep(10)
     if not args.chat:
         try:
             element = browser.find_elements_by_css_selector('button[aria-label^="Users and messages toggle"]')[0]


### PR DESCRIPTION
In four out of five times, the chat message could not be posted on my
setup. This "fix" moves the magic sleep before trying to post the
message, as this increases the chance of the overlay to have already
disappeared. For further issues, the logging was increased.